### PR TITLE
Add a Dockerfile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,7 +259,8 @@ install(TARGETS ${PROJECT_NAME}
     RUNTIME DESTINATION bin
 )
 install(FILES
-    ${PROJECT_SOURCE_DIR}/example_prog/generate_clang_kernel.sh
+    ${PROJECT_SOURCE_DIR}/example_prog/generate_clang_fatbin.sh
     ${PROJECT_SOURCE_DIR}/example_prog/generate_nvcc_fatbin.sh
     DESTINATION bin
+    PERMISSIONS WORLD_EXECUTE
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,11 @@ add_definitions(
 )
 
 find_package(CUDA REQUIRED)
+message(CUDART: ${CUDA_CUDART_LIBRARY})
+
+if(NOT CUDA_CUDART_LIBRARY)
+    message(WARNING "CUDA Runtime Library (shared) not found!")
+endif()
 
 #generate config c++-header-file
 #contains configurations and system paths (e.g. cuda toolkit path)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM       ubuntu:bionic
+
+# general environment for docker
+ENV        DEBIAN_FRONTEND=noninteractive \
+           FORCE_UNSAFE_CONFIGURE=1
+
+RUN        apt-get update \
+           && apt-get install -y --no-install-recommends \
+              build-essential \
+              ca-certificates \
+              curl \
+              clang \
+              cmake \
+              git \
+              pkg-config \
+              libc6-dev \
+              libclang-dev \
+              libedit-dev \
+              llvm-dev \
+              lsb-release \
+              nvidia-cuda-toolkit \
+              wget \
+              zlib1g-dev \
+           && rm -rf /var/lib/apt/lists/*
+
+COPY       . /root/cri
+
+RUN        mkdir -p /root/build \
+           && cd /root/build \
+           && cmake ../cri \
+           && make -j2 \
+           && make install \
+           && rm -rf ../build/* \
+           && rm /root/cri/example_prog/*.sh
+
+# select supported host compiler for nvcc
+RUN        /bin/echo "alias nvcc='nvcc -ccbin clang++-3.8'" >> /etc/profile.d/nvcc.sh \
+           && sed -i 's/nvcc /nvcc -ccbin clang++-3.8 /g' /usr/local/bin/generate_nvcc_fatbin.sh
+
+CMD        cd /root/cri/example_prog \
+           && /bin/bash -l

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM       ubuntu:bionic
+FROM       nvidia/cuda:8.0-devel
 
 # general environment for docker
 ENV        DEBIAN_FRONTEND=noninteractive \
@@ -9,16 +9,16 @@ RUN        apt-get update \
               build-essential \
               ca-certificates \
               curl \
-              clang \
+              clang-3.8 \
+              clang-5.0 \
               cmake \
               git \
               pkg-config \
               libc6-dev \
-              libclang-dev \
+              libclang-5.0-dev \
               libedit-dev \
-              llvm-dev \
+              llvm-5.0-dev \
               lsb-release \
-              nvidia-cuda-toolkit \
               wget \
               zlib1g-dev \
            && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,10 @@ RUN        apt-get update \
               zlib1g-dev \
            && rm -rf /var/lib/apt/lists/*
 
+
 COPY       . /root/cri
 
-RUN        mkdir -p /root/build \
+RUN mkdir -p /root/build \
            && cd /root/build \
            && cmake ../cri \
            && make -j2 \

--- a/example_prog/generate_clang_fatbin.sh
+++ b/example_prog/generate_clang_fatbin.sh
@@ -1,4 +1,6 @@
-CUDA_PATH=/usr/local/cuda
+#!/usr/bin/env bash
+
+CUDA_BIN_PATH=$(dirname $(which nvcc))
 
 if [ $# -eq 0 ]
   then
@@ -21,8 +23,8 @@ mkdir tmp_folder
 cd tmp_folder
 clang++ -std=c++11 -emit-llvm -c ../${FILENAME}.cu -o clang_kernel.ll --cuda-gpu-arch=sm_20 --cuda-device-only
 llc -mcpu=sm_20 clang_kernel.ll -o clang_kernel.ptx
-${CUDA_PATH}/bin/ptxas -m64 -O0 --gpu-name sm_20 --output-file clang_kernel.sass clang_kernel.ptx
-${CUDA_PATH}/bin/fatbinary --cuda -64 --create clang_${FILENAME}.fatbin --image=profile=sm_20,file=clang_kernel.sass --image=profile=compute_20,file=clang_kernel.ptx
+${CUDA_BIN_PATH}/ptxas -m64 -O0 --gpu-name sm_20 --output-file clang_kernel.sass clang_kernel.ptx
+${CUDA_BIN_PATH}/fatbinary --cuda -64 --create clang_${FILENAME}.fatbin --image=profile=sm_20,file=clang_kernel.sass --image=profile=compute_20,file=clang_kernel.ptx
 mv clang_${FILENAME}.fatbin ..
 cd ..
 rm -r tmp_folder

--- a/example_prog/generate_nvcc_fatbin.sh
+++ b/example_prog/generate_nvcc_fatbin.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 if [ $# -eq 0 ]
   then
     echo "usage: ./generate_clang_kernel.sh <file>.cu"

--- a/include/Config.hpp.in
+++ b/include/Config.hpp.in
@@ -13,6 +13,6 @@
 //add debug information to the jited code and allow debugging with the gdb (also need the flag -g as argument at start of the cuda-interpreter)
 #define CUI_DEBUG_JIT_INFO 1
 
-//path of the current cuda installation
+//runtime library of of the current cuda installation
 //necessary for automatic libcudart.so load 
-#define CUI_CUDA_TOOLKIT_PATH "@CUDA_TOOLKIT_ROOT_DIR@"
+#define CUI_CUDA_RT_LIBRARY "@CUDA_CUDART_LIBRARY@"

--- a/src/Backend.cpp
+++ b/src/Backend.cpp
@@ -51,7 +51,7 @@ int myBackend::executeJIT(std::shared_ptr<llvm::Module> module){
   llvm::TargetMachine * targetMachine = Target->createTargetMachine(module->getTargetTriple(), "generic", "", TO, RM);
       
   myBackend::OrcJIT orcJitExecuter(targetMachine);
-  orcJitExecuter.setDynamicLibrary(std::string(CUI_CUDA_TOOLKIT_PATH) + "/lib64/libcudart.so");
+  orcJitExecuter.setDynamicLibrary(std::string(CUI_CUDA_RT_LIBRARY));
   orcJitExecuter.addModule(module);
   
   return orcJitExecuter.runMain(1, nullptr);


### PR DESCRIPTION
Add a Dockerfile for [nvidia-docker2](https://github.com/NVIDIA/nvidia-docker) for easier testing.

Build and start like this when inside the repo:
```bash
docker build -t cri .
docker run --runtime=nvidia -it cri
```

- [x] You can then as usual test the prototype, e.g. via:
```bash
generate_nvcc_fatbin.sh hello.cu
cuda-interpreter -cuda_cpp hello.cu -fatbin nvcc_hello.fatbin -v
```

```
Hello World
```

- [x] or

```bash
generate_nvcc_fatbin.sh runtime.cu
cuda-interpreter -cuda_cpp runtime.cu -fatbin nvcc_runtime.fatbin -v
```

```
The program works fine! The right anwser is: 42
```

---

Nevertheless, this currently throws a runtime error for me:
```
/usr/lib64/libcudart.so: cannot open shared object file: No such file or directory
LLVM ERROR: Program used external function '__cudaRegisterFatBinary' which could not be resolved!
```

**update:** fixed hard coded paths now, see below